### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ jobs:
   test:
 
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/EliasOenal/term-cli/security/code-scanning/1](https://github.com/EliasOenal/term-cli/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for the specific job to restrict the `GITHUB_TOKEN` to the least privilege required. For this workflow, the steps only need to read repository contents, so `contents: read` is sufficient. Adding `permissions: contents: read` at the job level directly addresses the CodeQL warning on the highlighted job.

The best minimal change without altering existing functionality is to add a `permissions` section under the `test` job, alongside `runs-on`. This keeps the scope of permissions local to that job and does not affect any other workflows or jobs that might exist elsewhere in the repository. Concretely, in `.github/workflows/test.yml`, modify the `test` job definition so that immediately after `runs-on: ${{ matrix.os }}` you add:

```yaml
    permissions:
      contents: read
```

No additional methods, imports, or definitions are needed; this is purely a YAML configuration change inside the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
