### PR TITLE
Fix file handle leaks in download functions

### DIFF
--- a/term-cli
+++ b/term-cli
@@ -1557,7 +1557,8 @@ def cmd_download_pipe(src, checkpoint_lines):
     """Download via stdout (for pipe-pane capture).  Outputs framed base64."""
     _enter_alt()
     try:
-        data = open(src, 'rb').read()
+        with open(src, 'rb') as f:
+            data = f.read()
     except (OSError, IOError) as e:
         _die('read failed: ' + str(e))
 
@@ -1619,7 +1620,8 @@ def cmd_download_chunked(src, chunk_size):
     """
     _enter_alt()
     try:
-        raw_data = open(src, 'rb').read()
+        with open(src, 'rb') as f:
+            raw_data = f.read()
     except (OSError, IOError) as e:
         _die('read failed: ' + str(e))
 


### PR DESCRIPTION
## Summary

Fix file handle leaks in `cmd_download_pipe()` and `cmd_download_chunked()` functions by using context managers for file operations.

## Problem

File handles opened with `open(src, 'rb').read()` were not explicitly closed, relying on CPython's reference counting garbage collection. This could lead to resource leaks in other Python implementations or in edge cases where the file object isn't immediately garbage collected.

## Changes

- `cmd_download_pipe()`: Changed `data = open(src, 'rb').read()` to use a context manager
- `cmd_download_chunked()`: Changed `raw_data = open(src, 'rb').read()` to use a context manager

## Testing

All 692 existing tests pass with this change.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>